### PR TITLE
Add basic type bindings & lay groundwork for JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,16 @@ set(SRCS
   src/osrm_nb.cpp
   src/engineconfig_nb.cpp
   src/utility/osrm_kwargs.cpp
+
   src/parameters/baseparameter_nb.cpp
   src/parameters/routeparameter_nb.cpp
+  
+  src/types/optional_nb.cpp
+  src/types/status_nb.cpp
+  src/types/coordinate_nb.cpp
+  src/types/jsoncontainer_nb.cpp
+  src/types/approach_nb.cpp
+  src/types/bearing_nb.cpp
 )
 nanobind_add_module(
   ${EXT_NAME}

--- a/include/types/approach_nb.h
+++ b/include/types/approach_nb.h
@@ -1,0 +1,8 @@
+#ifndef OSRM_NB_APPROACH_H
+#define OSRM_NB_APPROACH_H
+
+#include <nanobind/nanobind.h>
+
+void init_Approach(nanobind::module_& m);
+
+#endif //OSRM_NB_APPROACH_H

--- a/include/types/bearing_nb.h
+++ b/include/types/bearing_nb.h
@@ -1,0 +1,8 @@
+#ifndef OSRM_NB_BEARING_H
+#define OSRM_NB_BEARING_H
+
+#include <nanobind/nanobind.h>
+
+void init_Bearing(nanobind::module_& m);
+
+#endif //OSRM_NB_BEARING_H

--- a/include/types/coordinate_nb.h
+++ b/include/types/coordinate_nb.h
@@ -1,0 +1,8 @@
+#ifndef OSRM_NB_COORDINATE_H
+#define OSRM_NB_COORDINATE_H
+
+#include <nanobind/nanobind.h>
+
+void init_Coordinate(nanobind::module_& m);
+
+#endif //OSRM_NB_COORDINATE_H

--- a/include/types/jsoncontainer_nb.h
+++ b/include/types/jsoncontainer_nb.h
@@ -1,0 +1,8 @@
+#ifndef OSRM_NB_JSONCONTAINER_H
+#define OSRM_NB_JSONCONTAINER_H
+
+#include <nanobind/nanobind.h>
+
+void init_JSONContainer(nanobind::module_& m);
+
+#endif //OSRM_NB_JSONCONTAINER_H

--- a/include/types/optional_nb.h
+++ b/include/types/optional_nb.h
@@ -1,0 +1,8 @@
+#ifndef OSRM_NB_OPTIONAL_H
+#define OSRM_NB_OPTIONAL_H
+
+#include <nanobind/nanobind.h>
+
+void init_Optional(nanobind::module_& m);
+
+#endif //OSRM_NB_OPTIONAL_H

--- a/include/types/status_nb.h
+++ b/include/types/status_nb.h
@@ -1,0 +1,8 @@
+#ifndef OSRM_NB_STATUS_H
+#define OSRM_NB_STATUS_H
+
+#include <nanobind/nanobind.h>
+
+void init_Status(nanobind::module_& m);
+
+#endif //OSRM_NB_STATUS_H

--- a/src/osrm_nb.cpp
+++ b/src/osrm_nb.cpp
@@ -7,6 +7,12 @@
 
 #include "engineconfig_nb.h"
 #include "utility/osrm_kwargs.h"
+#include "types/approach_nb.h"
+#include "types/bearing_nb.h"
+#include "types/coordinate_nb.h"
+#include "types/jsoncontainer_nb.h"
+#include "types/optional_nb.h"
+#include "types/status_nb.h"
 #include "parameters/baseparameter_nb.h"
 #include "parameters/routeparameter_nb.h"
 
@@ -21,6 +27,14 @@ NB_MODULE(osrm_ext, m) {
     using osrm::engine::api::RouteParameters;
 
     init_EngineConfig(m);
+
+    init_Approach(m);
+    init_Bearing(m);
+    init_Coordinate(m);
+    init_JSONContainer(m);
+    init_Optional(m);
+    init_Status(m);
+
     init_BaseParameters(m);
     init_RouteParameters(m);
 

--- a/src/parameters/routeparameter_nb.cpp
+++ b/src/parameters/routeparameter_nb.cpp
@@ -62,7 +62,7 @@ void init_RouteParameters(nb::module_& m) {
                 "geometries"_a,
                 "overview"_a,
                 "continue_straight"_a,
-                "waypoints"_a,
+                "waypoints"_a = std::vector<std::size_t>(),
                     "coordinates"_a = std::vector<osrm::util::Coordinate>(),
                     "hints"_a = std::vector<boost::optional<osrm::engine::Hint>>(),
                     "radiuses"_a = std::vector<boost::optional<double>>(),

--- a/src/parameters/routeparameter_nb.cpp
+++ b/src/parameters/routeparameter_nb.cpp
@@ -27,7 +27,7 @@ void init_RouteParameters(nb::module_& m) {
         .export_values();
 
     nb::enum_<RouteParameters::AnnotationsType>(m, "AnnotationsType", nb::is_arithmetic())
-        .value("None", RouteParameters::AnnotationsType::None)
+        .value("None_", RouteParameters::AnnotationsType::None)
         .value("Duration", RouteParameters::AnnotationsType::Duration)
         .value("Nodes", RouteParameters::AnnotationsType::Nodes)
         .value("Distance", RouteParameters::AnnotationsType::Distance)

--- a/src/py_osrm/__init__.py
+++ b/src/py_osrm/__init__.py
@@ -1,1 +1,17 @@
-from .osrm_ext import OSRM, EngineConfig, Algorithm, RouteParameters
+from .osrm_ext import (
+    OSRM,
+    EngineConfig,
+    Algorithm,
+
+    RouteParameters,
+    GeometriesType,
+    AnnotationsType,
+    SnappingType,
+    OverviewType,
+    Object,
+
+    Approach,
+    Bearing,
+    Coordinate,
+    Status
+)

--- a/src/py_osrm/__init__.py
+++ b/src/py_osrm/__init__.py
@@ -8,10 +8,5 @@ from .osrm_ext import (
     AnnotationsType,
     SnappingType,
     OverviewType,
-    Object,
-
-    Approach,
-    Bearing,
-    Coordinate,
-    Status
+    Object
 )

--- a/src/types/approach_nb.cpp
+++ b/src/types/approach_nb.cpp
@@ -1,0 +1,14 @@
+#include "engine/approach.hpp"
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+void init_Approach(nb::module_& m) {
+    using osrm::engine::Approach;
+
+    nb::enum_<Approach>(m, "Approach")
+        .value("CURB", Approach::CURB)
+        .value("UNRESTRICTED", Approach::UNRESTRICTED)
+        .export_values();
+}

--- a/src/types/bearing_nb.cpp
+++ b/src/types/bearing_nb.cpp
@@ -1,0 +1,24 @@
+#include "engine/bearing.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
+#include <nanobind/stl/pair.h>
+
+namespace nb = nanobind;
+
+void init_Bearing(nb::module_& m) {
+    using osrm::engine::Bearing;
+
+    nb::class_<Bearing>(m, "Bearing")
+        .def(nb::init<>())
+        .def("__init__", [](Bearing* t, std::pair<short, short> pair) {
+            new (t) Bearing{pair.first, pair.second};
+         })
+        .def_rw("bearing", &Bearing::bearing)
+        .def_rw("range", &Bearing::range)
+        .def("IsValid", &Bearing::IsValid)
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self);
+
+    nb::implicitly_convertible<std::pair<short, short>, Bearing>();
+}

--- a/src/types/bearing_nb.cpp
+++ b/src/types/bearing_nb.cpp
@@ -11,7 +11,7 @@ void init_Bearing(nb::module_& m) {
 
     nb::class_<Bearing>(m, "Bearing")
         .def(nb::init<>())
-        .def("__init__", [](Bearing* t, std::pair<short, short> pair) {
+        .def("__init__", [](Bearing* t, std::pair<int16_t, int16_t> pair) {
             new (t) Bearing{pair.first, pair.second};
          })
         .def_rw("bearing", &Bearing::bearing)
@@ -19,6 +19,5 @@ void init_Bearing(nb::module_& m) {
         .def("IsValid", &Bearing::IsValid)
         .def(nb::self == nb::self)
         .def(nb::self != nb::self);
-
-    nb::implicitly_convertible<std::pair<short, short>, Bearing>();
+    nb::implicitly_convertible<std::pair<int16_t, int16_t>, Bearing>();
 }

--- a/src/types/coordinate_nb.cpp
+++ b/src/types/coordinate_nb.cpp
@@ -13,28 +13,10 @@ void init_Coordinate(nb::module_& m) {
     using FloatLatitude = osrm::Alias<double, tag::latitude>;
     
     using osrm::util::Coordinate;
-    using osrm::util::FloatCoordinate;
-
-    nb::class_<FloatCoordinate>(m, "FloatCoordinate")
-        .def(nb::init<>())
-        .def(nb::init<const Coordinate>(), "other"_a)
-        .def("__init__", [](FloatCoordinate* t, std::pair<double, double> coords) {
-            const FloatLongitude lon_ = FloatLongitude{coords.first};
-            const FloatLatitude lat_ = FloatLatitude{coords.second};
-
-            new (t) FloatCoordinate(lon_, lat_);
-         })
-        .def_rw("lon", &FloatCoordinate::lon)
-        .def_rw("lat", &FloatCoordinate::lat)
-        .def("IsValid", &FloatCoordinate::IsValid)
-        .def(nb::self == nb::self)
-        .def(nb::self != nb::self);
-    nb::implicitly_convertible<std::pair<double, double>, FloatCoordinate>();
 
     nb::class_<Coordinate>(m, "Coordinate")
         .def(nb::init<>())
         .def(nb::init<const Coordinate&>(),"coordinate"_a)
-        .def(nb::init<const FloatCoordinate&>(), "other"_a)
         .def("__init__", [](Coordinate* t, std::pair<double, double> coords) {
             const FloatLongitude lon_ = FloatLongitude{coords.first};
             const FloatLatitude lat_ = FloatLatitude{coords.second};

--- a/src/types/coordinate_nb.cpp
+++ b/src/types/coordinate_nb.cpp
@@ -1,0 +1,81 @@
+#include "util/coordinate.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/operators.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/pair.h>
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+void init_Coordinate(nb::module_& m) {    
+    namespace tag = osrm::util::tag;
+    using FixedLatitude = osrm::Alias<int32_t, tag::latitude>;
+    using FixedLongitude = osrm::Alias<int32_t, tag::longitude>;
+    using FloatLatitude = osrm::Alias<double, tag::latitude>;
+    using FloatLongitude = osrm::Alias<double, tag::longitude>;
+    using UnsafeFloatLatitude = osrm::Alias<double, tag::unsafelatitude>;
+    using UnsafeFloatLongitude = osrm::Alias<double, tag::unsafelongitude>;
+
+    using osrm::util::Coordinate;
+    using osrm::util::FloatCoordinate;
+
+    nb::class_<FixedLatitude>(m, "FixedLatitude")
+        .def(nb::init<>())
+        .def(nb::init<int32_t>());
+    nb::class_<FloatLatitude>(m, "FloatLatitude")
+        .def(nb::init<>())
+        .def(nb::init<double>());
+    nb::class_<UnsafeFloatLatitude>(m, "UnsafeFloatLatitude")
+        .def(nb::init<>())
+        .def(nb::init<double>())
+        .def(nb::init_implicit<double>());
+
+    nb::class_<FixedLongitude>(m, "FixedLongitude")
+        .def(nb::init<>())
+        .def(nb::init<int32_t>());
+    nb::class_<FloatLongitude>(m, "FloatLongitude")
+        .def(nb::init<>())
+        .def(nb::init<double>());
+    nb::class_<UnsafeFloatLongitude>(m, "UnsafeFloatLongitude")
+        .def(nb::init<>())
+        .def(nb::init<double>())
+        .def(nb::init_implicit<double>());
+
+    nb::class_<FloatCoordinate>(m, "FloatCoordinate")
+        .def(nb::init<>())
+        .def(nb::init<const Coordinate>(), "other"_a)
+        .def(nb::init<const FixedLongitude, const FixedLatitude>(),
+            "lon"_a, "lat"_a)
+        .def(nb::init<const FloatLongitude, const FloatLatitude>(),
+            "lon"_a, "lat"_a)
+        .def_rw("lon", &FloatCoordinate::lon)
+        .def_rw("lat", &FloatCoordinate::lat)
+        .def("IsValid", &FloatCoordinate::IsValid)
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self);
+
+    nb::class_<Coordinate>(m, "Coordinate")
+        .def(nb::init<>())
+        .def(nb::init<const Coordinate&>(),"coordinate"_a)
+        .def(nb::init<const FloatCoordinate&>(), "other"_a)
+        .def(nb::init<const FixedLongitude, const FixedLatitude>(),
+            "lon"_a, "lat"_a)
+        .def(nb::init<const FloatLongitude, const FloatLatitude>(),
+            "lon"_a, "lat"_a)
+        .def(nb::init<const UnsafeFloatLongitude, const UnsafeFloatLatitude>(),
+            "lon"_a, "lat"_a)
+        .def("__init__", [](Coordinate* t, std::pair<double, double> coords) {
+            const UnsafeFloatLongitude lon_ = UnsafeFloatLongitude{coords.first};
+            const UnsafeFloatLatitude lat_ = UnsafeFloatLatitude{coords.second};
+
+            new (t) Coordinate(lon_, lat_);
+         })
+        .def_rw("lon", &Coordinate::lon)
+        .def_rw("lat", &Coordinate::lat)
+        .def("IsValid", &Coordinate::IsValid)
+        .def(nb::self == nb::self)
+        .def(nb::self != nb::self);
+
+    nb::implicitly_convertible<std::pair<double, double>, Coordinate>();
+}

--- a/src/types/coordinate_nb.cpp
+++ b/src/types/coordinate_nb.cpp
@@ -2,7 +2,6 @@
 
 #include <nanobind/nanobind.h>
 #include <nanobind/operators.h>
-#include <nanobind/stl/string.h>
 #include <nanobind/stl/pair.h>
 
 namespace nb = nanobind;
@@ -10,64 +9,35 @@ using namespace nb::literals;
 
 void init_Coordinate(nb::module_& m) {    
     namespace tag = osrm::util::tag;
-    using FixedLatitude = osrm::Alias<int32_t, tag::latitude>;
-    using FixedLongitude = osrm::Alias<int32_t, tag::longitude>;
-    using FloatLatitude = osrm::Alias<double, tag::latitude>;
     using FloatLongitude = osrm::Alias<double, tag::longitude>;
-    using UnsafeFloatLatitude = osrm::Alias<double, tag::unsafelatitude>;
-    using UnsafeFloatLongitude = osrm::Alias<double, tag::unsafelongitude>;
-
+    using FloatLatitude = osrm::Alias<double, tag::latitude>;
+    
     using osrm::util::Coordinate;
     using osrm::util::FloatCoordinate;
-
-    nb::class_<FixedLatitude>(m, "FixedLatitude")
-        .def(nb::init<>())
-        .def(nb::init<int32_t>());
-    nb::class_<FloatLatitude>(m, "FloatLatitude")
-        .def(nb::init<>())
-        .def(nb::init<double>());
-    nb::class_<UnsafeFloatLatitude>(m, "UnsafeFloatLatitude")
-        .def(nb::init<>())
-        .def(nb::init<double>())
-        .def(nb::init_implicit<double>());
-
-    nb::class_<FixedLongitude>(m, "FixedLongitude")
-        .def(nb::init<>())
-        .def(nb::init<int32_t>());
-    nb::class_<FloatLongitude>(m, "FloatLongitude")
-        .def(nb::init<>())
-        .def(nb::init<double>());
-    nb::class_<UnsafeFloatLongitude>(m, "UnsafeFloatLongitude")
-        .def(nb::init<>())
-        .def(nb::init<double>())
-        .def(nb::init_implicit<double>());
 
     nb::class_<FloatCoordinate>(m, "FloatCoordinate")
         .def(nb::init<>())
         .def(nb::init<const Coordinate>(), "other"_a)
-        .def(nb::init<const FixedLongitude, const FixedLatitude>(),
-            "lon"_a, "lat"_a)
-        .def(nb::init<const FloatLongitude, const FloatLatitude>(),
-            "lon"_a, "lat"_a)
+        .def("__init__", [](FloatCoordinate* t, std::pair<double, double> coords) {
+            const FloatLongitude lon_ = FloatLongitude{coords.first};
+            const FloatLatitude lat_ = FloatLatitude{coords.second};
+
+            new (t) FloatCoordinate(lon_, lat_);
+         })
         .def_rw("lon", &FloatCoordinate::lon)
         .def_rw("lat", &FloatCoordinate::lat)
         .def("IsValid", &FloatCoordinate::IsValid)
         .def(nb::self == nb::self)
         .def(nb::self != nb::self);
+    nb::implicitly_convertible<std::pair<double, double>, FloatCoordinate>();
 
     nb::class_<Coordinate>(m, "Coordinate")
         .def(nb::init<>())
         .def(nb::init<const Coordinate&>(),"coordinate"_a)
         .def(nb::init<const FloatCoordinate&>(), "other"_a)
-        .def(nb::init<const FixedLongitude, const FixedLatitude>(),
-            "lon"_a, "lat"_a)
-        .def(nb::init<const FloatLongitude, const FloatLatitude>(),
-            "lon"_a, "lat"_a)
-        .def(nb::init<const UnsafeFloatLongitude, const UnsafeFloatLatitude>(),
-            "lon"_a, "lat"_a)
         .def("__init__", [](Coordinate* t, std::pair<double, double> coords) {
-            const UnsafeFloatLongitude lon_ = UnsafeFloatLongitude{coords.first};
-            const UnsafeFloatLatitude lat_ = UnsafeFloatLatitude{coords.second};
+            const FloatLongitude lon_ = FloatLongitude{coords.first};
+            const FloatLatitude lat_ = FloatLatitude{coords.second};
 
             new (t) Coordinate(lon_, lat_);
          })
@@ -76,6 +46,5 @@ void init_Coordinate(nb::module_& m) {
         .def("IsValid", &Coordinate::IsValid)
         .def(nb::self == nb::self)
         .def(nb::self != nb::self);
-
     nb::implicitly_convertible<std::pair<double, double>, Coordinate>();
 }

--- a/src/types/jsoncontainer_nb.cpp
+++ b/src/types/jsoncontainer_nb.cpp
@@ -1,0 +1,47 @@
+#include "util/json_container.hpp"
+
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/unordered_map.h>
+#include <nanobind/stl/string.h>
+
+namespace nb = nanobind;
+
+void init_JSONContainer(nb::module_& m) {
+    namespace json = osrm::util::json;
+
+    nb::class_<json::Object>(m, "Object")
+        .def(nb::init<>())
+        .def_rw("values", &json::Object::values);
+
+    nb::class_<json::Array>(m, "Array")
+        .def(nb::init<>())
+        .def_rw("values", &json::Array::values);
+
+    nb::class_<json::String>(m, "String")
+        .def(nb::init<>())
+        .def(nb::init<std::string>())
+        .def_rw("value", &json::String::value);
+
+    nb::class_<json::Number>(m, "Number")
+        .def(nb::init<>())
+        .def(nb::init<double>())
+        .def_rw("value", &json::Number::value);
+
+    nb::class_<json::True>(m, "True")
+        .def(nb::init<>());
+    nb::class_<json::False>(m, "False")
+        .def(nb::init<>());
+    nb::class_<json::Null>(m, "Null")
+        .def(nb::init<>());
+
+    using Value = mapbox::util::variant<json::String,
+                                        json::Number,
+                                        mapbox::util::recursive_wrapper<json::Object>,
+                                        mapbox::util::recursive_wrapper<json::Array>,
+                                        json::True,
+                                        json::False,
+                                        json::Null>;
+    nb::class_<Value>(m, "Value")
+        .def(nb::init<>())
+        .def("valid", &Value::valid);
+}

--- a/src/types/jsoncontainer_nb.cpp
+++ b/src/types/jsoncontainer_nb.cpp
@@ -1,31 +1,99 @@
 #include "util/json_container.hpp"
 
+#include <mapbox/variant.hpp>
+
 #include <nanobind/nanobind.h>
-#include <nanobind/stl/unordered_map.h>
+#include <nanobind/make_iterator.h>
 #include <nanobind/stl/string.h>
 
 namespace nb = nanobind;
+namespace json = osrm::util::json;
+
+using JSONValue = mapbox::util::variant<json::String,
+                                        json::Number,
+                                        mapbox::util::recursive_wrapper<json::Object>,
+                                        mapbox::util::recursive_wrapper<json::Array>,
+                                        json::True,
+                                        json::False,
+                                        json::Null>;
+
+//Custom Type Casters
+namespace nanobind::detail {
+
+template <> struct type_caster<JSONValue> : type_caster_base<JSONValue> {
+    template <typename T> using Caster = make_caster<detail::intrinsic_t<T>>;
+
+    template <typename T>
+    static handle from_cpp(T&& val, rv_policy policy, cleanup_list* cleanup) noexcept {
+        return mapbox::util::apply_visitor([&](auto &&v) {
+            return Caster<decltype(v)>::from_cpp(std::forward<decltype(v)>(v), policy, cleanup);
+        }, std::forward<T>(val));
+    }
+};
+
+template <> struct type_caster<json::String> : type_caster_base<json::String> {
+    static handle from_cpp(const json::String& val, rv_policy, cleanup_list*) noexcept {
+        return PyUnicode_FromStringAndSize(val.value.c_str(), val.value.size());
+    }
+};
+template <> struct type_caster<json::Number> : type_caster_base<json::Number> {
+    static handle from_cpp(const json::Number& val, rv_policy, cleanup_list*) noexcept {
+        return PyFloat_FromDouble((double)val.value);
+    }
+};
+
+template <> struct type_caster<json::True> : type_caster_base<json::True> {
+    static handle from_cpp(const json::True&, rv_policy, cleanup_list*) noexcept {
+        return handle(Py_True).inc_ref();
+    }
+};
+template <> struct type_caster<json::False> : type_caster_base<json::False> {
+    static handle from_cpp(const json::False&, rv_policy, cleanup_list*) noexcept {
+        return handle(Py_False).inc_ref();
+    }
+};
+template <> struct type_caster<json::Null> : type_caster_base<json::Null> {
+    static handle from_cpp(const json::Null&, rv_policy, cleanup_list*) noexcept {
+        return none().release();
+    }
+};
+
+} //nanobind::detail
 
 void init_JSONContainer(nb::module_& m) {
-    namespace json = osrm::util::json;
-
     nb::class_<json::Object>(m, "Object")
         .def(nb::init<>())
-        .def_rw("values", &json::Object::values);
+        .def("__len__", [](const json::Object& obj) {
+            return obj.values.size();
+        })
+        .def("__bool__", [](const json::Object& obj) {
+            return obj.values.empty();
+        })
+        .def("__getitem__", [](json::Object& obj, const std::string& key) {
+            return obj.values[key];
+        })
+        .def("__iter__", [](const json::Object& obj) {
+            return nb::make_iterator(nb::type<json::Value>(), "iterator",
+                                    obj.values.begin(), obj.values.end());
+        }, nb::keep_alive<0, 1>());
 
     nb::class_<json::Array>(m, "Array")
         .def(nb::init<>())
-        .def_rw("values", &json::Array::values);
+        .def("__len__", [](const json::Array& arr) {
+            return arr.values.size();
+        })
+        .def("__bool__", [](const json::Array& arr) {
+            return arr.values.empty();
+        })
+        .def("__iter__", [](const json::Array& arr) {
+            return nb::make_iterator(nb::type<json::Value>(), "iterator",
+                                    arr.values.begin(), arr.values.end());
+        }, nb::keep_alive<0, 1>());
 
     nb::class_<json::String>(m, "String")
-        .def(nb::init<>())
-        .def(nb::init<std::string>())
-        .def_rw("value", &json::String::value);
-
+        .def(nb::init<std::string>());
     nb::class_<json::Number>(m, "Number")
-        .def(nb::init<>())
-        .def(nb::init<double>())
-        .def_rw("value", &json::Number::value);
+        .def(nb::init<double>());
 
     nb::class_<json::True>(m, "True")
         .def(nb::init<>());
@@ -33,15 +101,4 @@ void init_JSONContainer(nb::module_& m) {
         .def(nb::init<>());
     nb::class_<json::Null>(m, "Null")
         .def(nb::init<>());
-
-    using Value = mapbox::util::variant<json::String,
-                                        json::Number,
-                                        mapbox::util::recursive_wrapper<json::Object>,
-                                        mapbox::util::recursive_wrapper<json::Array>,
-                                        json::True,
-                                        json::False,
-                                        json::Null>;
-    nb::class_<Value>(m, "Value")
-        .def(nb::init<>())
-        .def("valid", &Value::valid);
 }

--- a/src/types/optional_nb.cpp
+++ b/src/types/optional_nb.cpp
@@ -1,6 +1,7 @@
 #include "engine/api/base_parameters.hpp"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/pair.h>
 
 namespace nb = nanobind;
 
@@ -17,15 +18,19 @@ void init_Optional(nb::module_& m) {
         .def(nb::init<double>())
         .def(nb::init_implicit<double>());
 
-    using OptionalBearing = boost::optional<osrm::engine::Bearing>;
-    nb::class_<OptionalBearing>(m, "OptionalBearing")
-        .def(nb::init<>())
-        .def(nb::init<osrm::engine::Bearing>())
-        .def(nb::init_implicit<osrm::engine::Bearing>());
-
     using OptionalApproach = boost::optional<osrm::engine::Approach>;
     nb::class_<OptionalApproach>(m, "OptionalApproach")
         .def(nb::init<>())
         .def(nb::init<osrm::engine::Approach>())
         .def(nb::init_implicit<osrm::engine::Approach>());
+
+    using OptionalBearing = boost::optional<osrm::engine::Bearing>;
+    nb::class_<OptionalBearing>(m, "OptionalBearing")
+        .def(nb::init<>())
+        .def(nb::init<osrm::engine::Bearing>())
+        .def(nb::init_implicit<osrm::engine::Bearing>())
+        .def("__init__", [](OptionalBearing* t, std::pair<int16_t, int16_t> pair) {
+            new (t) OptionalBearing({pair.first, pair.second});
+         });
+    nb::implicitly_convertible<std::pair<int16_t, int16_t>, OptionalBearing>();
 }

--- a/src/types/optional_nb.cpp
+++ b/src/types/optional_nb.cpp
@@ -1,0 +1,31 @@
+#include "engine/api/base_parameters.hpp"
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+void init_Optional(nb::module_& m) {
+    using OptionalBool = boost::optional<bool>;
+    nb::class_<OptionalBool>(m, "OptionalBool")
+        .def(nb::init<>())
+        .def(nb::init<bool>())
+        .def(nb::init_implicit<bool>());
+
+    using OptionalDouble = boost::optional<double>;
+    nb::class_<OptionalDouble>(m, "OptionalDouble")
+        .def(nb::init<>())
+        .def(nb::init<double>())
+        .def(nb::init_implicit<double>());
+
+    using OptionalBearing = boost::optional<osrm::engine::Bearing>;
+    nb::class_<OptionalBearing>(m, "OptionalBearing")
+        .def(nb::init<>())
+        .def(nb::init<osrm::engine::Bearing>())
+        .def(nb::init_implicit<osrm::engine::Bearing>());
+
+    using OptionalApproach = boost::optional<osrm::engine::Approach>;
+    nb::class_<OptionalApproach>(m, "OptionalApproach")
+        .def(nb::init<>())
+        .def(nb::init<osrm::engine::Approach>())
+        .def(nb::init_implicit<osrm::engine::Approach>());
+}

--- a/src/types/status_nb.cpp
+++ b/src/types/status_nb.cpp
@@ -10,5 +10,15 @@ void init_Status(nb::module_& m) {
     nb::enum_<Status>(m, "Status")
         .value("Ok", Status::Ok)
         .value("Error", Status::Error)
-        .export_values();
+        .export_values()
+        .def("__repr__", [](Status status) {
+            switch(status) {
+            case Status::Ok:
+                return "Ok";
+            case Status::Error:
+                return "Error";
+            default:
+                return "Undefined";
+            };
+        });
 }

--- a/src/types/status_nb.cpp
+++ b/src/types/status_nb.cpp
@@ -1,0 +1,14 @@
+#include "osrm/status.hpp"
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+void init_Status(nb::module_& m) {
+    using osrm::engine::Status;
+
+    nb::enum_<Status>(m, "Status")
+        .value("Ok", Status::Ok)
+        .value("Error", Status::Error)
+        .export_values();
+}

--- a/tests/test.py
+++ b/tests/test.py
@@ -3,12 +3,12 @@ import py_osrm
 config = py_osrm.EngineConfig()
 config.use_shared_memory = False
 config.algorithm = py_osrm.Algorithm.CH
-config.SetStorageConfig("./ch/monaco")
+config.SetStorageConfig("./test_data/ch/monaco")
 
 print(config.IsValid())
 
 engine = py_osrm.OSRM(
-    storage_config = "./ch/monaco", 
+    storage_config = "./test_data/ch/monaco", 
     use_shared_memory = False
 )
 
@@ -19,20 +19,34 @@ route_params = py_osrm.RouteParameters(
     geometries = py_osrm.GeometriesType.GeoJSON,
     overview = py_osrm.OverviewType.Full,
     continue_straight = True, #py_osrm.OptionalBool(True),
-    waypoints = [1],
-    coordinates = [(1.0, 2.0)],
-    radiuses = [3],
-    bearings = [py_osrm.Bearing((3,3))],
-    approaches = [py_osrm.Approach.CURB],
-    generate_hints = True,
-    exclude = [],
-    snapping = py_osrm.SnappingType.Default
+    coordinates = [(7.41337, 43.72956), (7.41546, 43.73077)]
 )
+
+# route_params = py_osrm.RouteParameters(
+#     steps = True, 
+#     alternatives = True, 
+#     annotations = py_osrm.AnnotationsType.None_,
+#     geometries = py_osrm.GeometriesType.GeoJSON,
+#     overview = py_osrm.OverviewType.Full,
+#     continue_straight = True, #py_osrm.OptionalBool(True),
+#     waypoints = [1],
+#     coordinates = [(1.0, 2.0)],
+#     radiuses = [3],
+#     bearings = [(3,3)], #[py_osrm.Bearing((3,3))], [py_osrm.OptionalBearing((3,3))]
+#     approaches = [py_osrm.Approach.CURB],
+#     generate_hints = True,
+#     exclude = [],
+#     snapping = py_osrm.SnappingType.Default
+# )
 
 result = py_osrm.Object()
 
 status = engine.Route(route_params, result)
 print(status)
 
-for key in result.values:
-    print(key, " ", result.values[key])
+print(result["code"])
+print(result["message"])
+
+for route in result["routes"]:
+    for obj in route:
+        print(obj)

--- a/tests/test.py
+++ b/tests/test.py
@@ -7,7 +7,32 @@ config.SetStorageConfig("./ch/monaco")
 
 print(config.IsValid())
 
-engine = py_osrm.OSRM(storage_config = "./ch/monaco", use_shared_memory = False)
+engine = py_osrm.OSRM(
+    storage_config = "./ch/monaco", 
+    use_shared_memory = False
+)
 
-route_params = py_osrm.RouteParameters()
-engine.Route(route_params)
+route_params = py_osrm.RouteParameters(
+    steps = True, 
+    alternatives = True, 
+    annotations = py_osrm.AnnotationsType.None_,
+    geometries = py_osrm.GeometriesType.GeoJSON,
+    overview = py_osrm.OverviewType.Full,
+    continue_straight = True, #py_osrm.OptionalBool(True),
+    waypoints = [1],
+    coordinates = [(1.0, 2.0)],
+    radiuses = [3],
+    bearings = [py_osrm.Bearing((3,3))],
+    approaches = [py_osrm.Approach.CURB],
+    generate_hints = True,
+    exclude = [],
+    snapping = py_osrm.SnappingType.Default
+)
+
+result = py_osrm.Object()
+
+status = engine.Route(route_params, result)
+print(status)
+
+for key in result.values:
+    print(key, " ", result.values[key])


### PR DESCRIPTION
Added more bindings for basic types, which allows, for example, proper parameter usage in RouteParameter (per test example). However, `Hint` support still needs to be added, but since it relies on a lot of other custom types, it requires some further thought on how to best approach it (ie. if there's room for simplification).

The Result object bindings part still needs to be worked on further in order to achieve proper functionality.