### PR TITLE
Add Documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+version: "2"
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,8 +1,51 @@
-# py-osrm
-Python bindings for the [osrm-backend project](https://github.com/Project-OSRM/osrm-backend), using nanobind.
+# py_osrm
+![PR_CI](https://github.com/gis-ops/py-osrm/actions/workflows/pull_request.yml/badge.svg)
 
-## Installing
-The package can be installed via the following command:
+### py_osrm is a Python package that binds to [osrm-backend](https://github.com/Project-OSRM/osrm-backend) using [nanobind](https://github.com/wjakob/nanobind).
+
+---
+
+## Supported Platforms
+Platform | Arch
+---|---
+Linux | x86_64
+MacOS | x86_64
+
+---
+
+## Installation
+py_osrm is supported on **Python 3.8+**, and can be installed from source via running the following command in the source folder:
 ```
-python3 -m pip install .
+pip install .
 ```
+
+## Example
+The following example will showcase the process of calculating routes between two coordinates.
+
+First, import the `py_osrm` library, and instantiate an instance of OSRM:
+```python
+import py_osrm
+
+# Instantiate py_osrm instance
+osrm = py_osrm.OSRM("./tests/test_data/ch/monaco.osrm")
+```
+
+Then, declare `RouteParameters`, and then pass it into the `py_osrm` instance:
+```python
+# Declare Route Parameters
+route_params = py_osrm.RouteParameters(
+    coordinates = [(7.41337, 43.72956), (7.41546, 43.73077)]
+)
+
+# Pass it into the py_osrm instance
+res = osrm.Route(route_params)
+
+# Print out result output
+print(res["waypoints"])
+print(res["routes"])
+```
+
+---
+
+## Documentation
+

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx==7.1.2
+sphinx-rtd-theme==1.3.0rc1
+furo==2023.8.17

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,35 @@
+# Configuration file for the Sphinx documentation builder.
+
+# -- Project information
+
+project = 'py_osrm'
+copyright = '2023'
+author = 'Project-OSRM'
+
+release = '0.1'
+version = '0.1.0'
+
+# -- General configuration
+
+extensions = [
+    'sphinx.ext.duration',
+    'sphinx.ext.doctest',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
+]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+}
+intersphinx_disabled_domains = ['std']
+
+templates_path = ['_templates']
+
+# -- Options for HTML output
+
+html_theme = 'furo'
+
+# -- Options for EPUB output
+epub_show_urls = 'footnote'

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,17 @@
+py_osrm
+=======
+**py_osrm** is a Python package that binds to Open Source Routing Machine's `osrm-backend <https://github.com/Project-OSRM/osrm-backend>`_ using `nanobind <https://github.com/wjakob/nanobind>`_.
+
+Check out the :doc:`usage` section for further information, including :ref:`installation`.
+
+.. note::
+   This project is still in active development. There may be rough edges, or parts that are not fully functional.
+
+Contents
+--------
+.. toctree::
+   :maxdepth: 2
+
+   usage
+   osrm
+   parameters

--- a/docs/source/osrm.rst
+++ b/docs/source/osrm.rst
@@ -1,0 +1,132 @@
+OSRM
+====
+OSRM
+----
+.. important::
+  OSRM responses are in JSON format. 
+  
+  For information on the format of the JSON response for each function, please refer to the `OSRM documentation <https://project-osrm.org/docs/v5.24.0/api/#result-objects>`_.
+
+.. code-block:: python
+   :caption: Instantiating OSRM
+
+   import py_osrm
+
+   # Instatiate OSRM by passing in Storage File Path
+   osrm = py_osrm.OSRM(".tests/test_data/ch/monaco.osrm")
+   # Or passing in EngineConfig Kwargs
+   osrm = py_osrm.OSRM(
+     algorithm = "CH",
+     storage_config = ".tests/test_data/ch/monaco.osrm",
+     max_locations_trip = 3,
+     max_locations_viaroute = 3,
+     max_locations_distance_table = 3,
+     max_locations_map_matching = 3,
+     max_results_nearest = 1,
+     max_alternatives = 1,
+     default_radius = "unlimited"
+   )
+
+
+.. list-table:: Instantiating OSRM
+  :widths: 75 125
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+  * - ``(String to Storage Path)``
+    - ``String``
+  * - ``<Engine Config Keyword Arguments>``
+    - Attributes from :ref:`engineconfig`
+
+
+.. code-block:: python
+   :caption: Routing Example
+
+   # Declare Route Coordinates
+   route_params = py_osrm.RouteParameters(
+      coordinates = [(7.41337, 43.72956), (7.41546, 43.73077)]
+   )
+
+   # Pass it into the py_osrm instance
+   res = osrm.Route(route_params)
+
+   # Print out the Distance and Duration of the first Route
+   print("Distance:", res["routes"][0]["distance"])
+   print("Duration:", res["routes"][0]["duration"])
+
+
+.. list-table:: OSRM Functions
+  :widths: 20 50 115 15
+  :header-rows: 1
+
+  * - Function
+    - Input
+    - Description
+    - Result
+  * - ``Match``
+    - :ref:`matchparameters`
+    - *Map matching matches/snaps given GPS points to the road network in the most plausible way.*
+    - `JSON <https://project-osrm.org/docs/v5.24.0/api/#match-service>`_
+  * - ``Nearest``
+    - :ref:`nearestparameters`
+    - *Snaps a coordinate to the street network and returns the nearest matches.*
+    - `JSON <https://project-osrm.org/docs/v5.24.0/api/#nearest-service>`_
+  * - ``Route``
+    - :ref:`routeparameters`
+    - *Finds the fastest route between coordinates in the supplied order.*
+    - `JSON <https://project-osrm.org/docs/v5.24.0/api/#route-service>`_
+  * - ``Table``
+    - :ref:`tableparameters`
+    - *Computes the duration of the fastest route between all pairs of supplied coordinates.*
+    - `JSON <https://project-osrm.org/docs/v5.24.0/api/#table-service>`_
+  * - ``Tile``
+    - :ref:`tileparameters`
+    - *This service generates Mapbox Vector Tiles that can be viewed with a vector-tile capable slippy-map viewer.*
+    - `JSON <https://project-osrm.org/docs/v5.24.0/api/#tile-service>`_
+  * - ``Trip``
+    - :ref:`tripparameters`
+    - *The trip plugin solves the Traveling Salesman Problem using a greedy heuristic (farthest-insertion algorithm).*
+    - `JSON <https://project-osrm.org/docs/v5.24.0/api/#trip-service>`_
+
+
+.. _engineconfig:
+
+EngineConfig
+-------------
+.. list-table:: EngineConfig Keyword Arguments
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+  * - ``storage_config``
+    - ``String``
+  * - ``max_locations_trip``
+    - ``Int``
+  * - ``max_locations_viaroute``
+    - ``Int``
+  * - ``max_locations_distance_table``
+    - ``Int``
+  * - ``max_locations_map_matching``
+    - ``Int``
+  * - ``max_radius_map_matching``
+    - ``Float``
+  * - ``max_results_nearest``
+    - ``Int``
+  * - ``default_radius``
+    - ``Float``, ``"unlimited"``, ``"UNLIMITED"``
+  * - ``max_alternatives``
+    - ``Int``
+  * - ``use_shared_memory``
+    - ``Bool``
+  * - ``memory_file``
+    - ``String``
+  * - ``use_mmap``
+    - ``Bool``
+  * - ``algorithm``
+    - ``CH`` (Default), ``CoreCH``, ``MLD``
+  * - ``verbosity``
+    - ``String``
+  * - ``dataset_name``
+    - ``String``

--- a/docs/source/parameters.rst
+++ b/docs/source/parameters.rst
@@ -1,0 +1,391 @@
+Parameters
+==========
+.. important::
+  For a primer on what each parameter does, please refer to the `OSRM documentation <https://project-osrm.org/docs/v5.24.0/api/#>`_.
+
+Keyword Arguments
+-----------------
+py_osrm's main routing functions accept keyword arguments.
+
+**Kwarg Example**:
+
+.. code-block:: python
+  :emphasize-lines: 4-10
+
+  import py_osrm
+
+  match_params = py_osrm.MatchParameters(
+    coordinates = three_test_coordinates,
+    timestamps = [1424684612, 1424684616, 1424684620],
+    radiuses = [4.07, 4.07, 4.07],
+    steps = True,
+    annotations = ["speed"],
+    overview = "false",
+    geometries = "geojson"
+  )
+
+
+.. _baseparameters:
+
+Base Parameters
+---------------
+.. note::
+  py_osrm's parameters generally share a parent class ``BaseParameters``.
+
+  This is applicable to:
+  :ref:`routeparameters`,
+  :ref:`matchparameters`,
+  :ref:`nearestparameters`,
+  :ref:`tableparameters`,
+  :ref:`tripparameters`
+
+.. list-table:: BaseParameters' Attributes
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+  * - ``coordinates``
+    - ``Array`` of ``Float`` ``Pairs``
+  * - ``hints``
+    - *Currently not supported*
+  * - ``radiuses``
+    - ``Array`` of ``Float``
+  * - ``bearings``
+    - ``Array`` of ``Int`` ``Pairs``
+  * - ``approaches``
+    - *Currently not supported*
+  * - ``exclude``
+    - ``Array`` of ``(class to avoid)``
+  * - ``format``
+    - ``"json"`` (default)
+  * - ``generate_hints``
+    - ``Bool``
+  * - ``skip_waypoints``
+    - ``Bool``
+  * - ``snapping``
+    - ``"default"`` (default), ``"any"``
+
+.. list-table:: BaseParameters' Functions
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Function
+    - Description
+  * - ``IsValid()``
+    - Runs a basic validation check on input parameter values, returning a Boolean ``True`` if valid, ``False`` if invalid
+
+
+.. _routeparameters:
+
+Route Parameters
+----------------
+.. note::
+  This class is a derived class of :ref:`baseparameters`
+
+.. code-block:: python
+
+  import py_osrm
+
+  # Declare Parameters
+  route_params = py_osrm.RouteParameters(
+    coordinates = [(7.41337, 43.72956), (7.41546, 43.73077)],
+    steps = True,
+    number_of_alternatives = 3,
+    annotations = ["speed"],
+    geometries = "polyline",
+    overview = "simplified",
+    continue_straight = False,
+    waypoints = [0, 1],
+    radiuses = [4.07, 4.07],
+    bearings = [(200, 180), (250, 180)],
+    # approaches = ["unrestricted", "unrestricted"],
+    generate_hints = False,
+    exclude = ["motorway"],
+    snapping = "any"
+  )
+  # Assign an Attribute Directly
+  route_params.steps = False
+
+  # Print out Validity Status
+  print("Valid:", route_params.IsValid())
+
+.. list-table:: RouteParameters' Attributes
+   :widths: 50 150
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``steps``
+     - ``Bool``
+   * - ``number_of_alternatives``
+     - ``Int``
+   * - ``annotations``
+     - ``Array`` of ``"none"`` (default), ``"duration"``, ``"nodes"``, ``"distance"``, ``"weight"``, ``"datasources"``, ``"speed"``, ``"all"``
+   * - ``geometries``
+     - ``"polyline"`` (default), ``"polyline6"``, ``"geojson"``
+   * - ``overview``
+     - ``"simplified"`` (default), ``"full"``, ``"false"``
+   * - ``continue_straight``
+     - ``Bool``
+   * - ``waypoints``
+     - ``Array`` of ``Int``
+   * - ``<Inherited Attributes>``
+     - Attributes from :ref:`baseparameters`
+
+.. list-table:: RouteParameters' Functions
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Function
+    - Description
+  * - ``<Inherited Functions>``
+    - Functions from :ref:`baseparameters`
+
+
+.. _matchparameters:
+
+Match Parameters
+----------------
+.. note::
+  This class is a derived class of :ref:`routeparameters`
+
+.. code-block:: python
+
+  import py_osrm
+
+  # Declare Parameters
+  match_params = py_osrm.MatchParameters(
+    coordinates = [(7.41337, 43.72956), (7.41546, 43.73077), (7.41862, 43.73216)],
+    timestamps = [1424684612, 1424684616, 1424684620],
+    gaps = "split",
+    tidy = True
+  )
+  # Assign an Attribute Directly
+  match_params.steps = False
+
+  # Print out Validity Status
+  print("Valid:", match_params.IsValid())
+
+.. list-table:: MatchParameters' Attributes
+   :widths: 50 150
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``timestamps``
+     - ``Unsigned Int``
+   * - ``gaps``
+     - ``"split"`` (Default), ``"ignore"``
+   * - ``tidy``
+     - ``Bool``
+   * - ``<Inherited Attributes>``
+     - Attributes from :ref:`routeparameters`
+   * - ``<Inherited Attributes>``
+     - Attributes from :ref:`baseparameters`
+
+.. list-table:: MatchParameters' Functions
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Function
+    - Description
+  * - ``<Inherited Functions>``
+    - Functions from :ref:`routeparameters`
+  * - ``<Inherited Functions>``
+    - Functions from :ref:`baseparameters`
+
+.. _nearestparameters:
+
+Nearest Parameters
+------------------
+.. note::
+  This class is a derived class of :ref:`baseparameters`
+
+.. code-block:: python
+
+  import py_osrm
+
+  # Declare Parameters
+  nearest_params = py_osrm.NearestParameters(
+    coordinates = [(7.41337, 43.72956)],
+    exclude = ["motorway"]
+  )
+  # Assign an Attribute Directly
+  nearest_params.skip_waypoints = False
+
+  # Print out Validity Status
+  print("Valid:", nearest_params.IsValid())
+
+.. list-table:: NearestParameters' Attributes
+   :widths: 50 150
+   :header-rows: 1
+
+   * - Parameter
+     - Description
+   * - ``<Inherited Attributes>``
+     - Attributes from :ref:`baseparameters`
+
+.. list-table:: NearestParameters' Functions
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Function
+    - Description
+  * - ``<Inherited Functions>``
+    - Functions from :ref:`baseparameters`
+
+
+.. _tableparameters:
+
+Table Parameters
+------------------
+.. note::
+  This class is a derived class of :ref:`baseparameters`
+
+.. code-block:: python
+
+  import py_osrm
+
+  # Declare Parameters
+  table_params = py_osrm.TableParameters(
+    coordinates = [(7.41337, 43.72956), (7.41546, 43.73077)],
+    sources = [0],
+    destinations = [1],
+    annotations = ["duration"],
+    fallback_speed = 1,
+    fallback_coordinate_type = "input",
+    scale_factor = 0.9
+  )
+  # Assign an Attribute Directly
+  table_params.skip_waypoints = False
+
+  # Print out Validity Status
+  print("Valid:", table_params.IsValid())
+
+.. list-table:: TableParameters' Attributes
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+  * - ``sources``
+    - ``Array`` of ``Int``
+  * - ``destinations``
+    - ``Array`` of ``Int``
+  * - ``annotations``
+    - ``Array`` of ``"none"`` (Default), ``"duration"``, ``"distance"``, ``"all"``
+  * - ``fallback_speed``
+    - ``Float``
+  * - ``fallback_coordinate_type``
+    - ``"input"`` (Default), ``"snapped"``
+  * - ``scale_factor``
+    - ``Float``
+  * - ``<Inherited Attributes>``
+    - Attributes from :ref:`baseparameters`
+
+.. list-table:: TableParameters' Functions
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Function
+    - Description
+  * - ``<Inherited Functions>``
+    - Functions from :ref:`baseparameters`
+
+
+.. _tileparameters:
+
+Tile Parameters
+------------------
+.. code-block:: python
+
+  import py_osrm
+
+  # Declare Parameters
+  tile_params = py_osrm.TileParameters([17059, 11948, 15])
+  tile_params = py_osrm.TileParameters(
+    x = 17059,
+    y = 11948,
+    z = 15
+  )
+  # Assign an Attribute Directly
+  tile_params.x = 17050
+
+  # Print out Validity Status
+  print("Valid:", tile_params.IsValid())
+
+.. list-table:: TileParameters' Attributes
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+  * - ``x``
+    - ``Unsigned Int``
+  * - ``y``
+    - ``Unsigned Int``
+  * - ``z``
+    - ``Unsigned Int``
+
+.. list-table:: TileParameters' Functions
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Function
+    - Description
+  * - ``IsValid()``
+    - Runs a basic validation check on input parameter values, returning a Boolean ``True`` if valid, ``False`` if invalid
+
+
+.. _tripparameters:
+
+Trip Parameters
+------------------
+.. note::
+  This class is a derived class of :ref:`routeparameters`
+
+.. code-block:: python
+
+  import py_osrm
+
+  # Declare Parameters
+  trip_params = py_osrm.TripParameters(
+    coordinates = [(7.41337, 43.72956), (7.41546, 43.73077)],
+    source = "any",
+    destination = "last",
+    roundtrip = False
+  )
+  # Assign an Attribute Directly
+  trip_params.overview = "false" 
+
+  # Print out Validity Status
+  print("Valid:", trip_params.IsValid())
+
+.. list-table:: TripParameters' Attributes
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+  * - ``source``
+    - ``"any"`` (Default), ``"first"``
+  * - ``destination``
+    - ``"any"`` (Default), ``"last"``
+  * - ``roundtrip``
+    - ``Bool``
+  * - ``<Inherited Attributes>``
+    - Attributes from :ref:`routeparameters`
+  * - ``<Inherited Attributes>``
+    - Attributes from :ref:`baseparameters`
+
+.. list-table:: TripParameters' Functions
+  :widths: 50 150
+  :header-rows: 1
+
+  * - Function
+    - Description
+  * - ``<Inherited Functions>``
+    - Functions from :ref:`routeparameters`
+  * - ``<Inherited Functions>``
+    - Functions from :ref:`baseparameters`

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,45 @@
+Usage
+=====
+
+.. _installation:
+
+Installation
+------------
+py_osrm can be installed via either pip (recommended) or source.
+
+pip:
+
+.. code-block:: console
+
+   $ pip install py_osrm
+
+source:
+
+.. code-block:: console
+   
+   $ git clone https://github.com/gis-ops/py-osrm.git
+   $ cd py-osrm
+   $ pip install .
+
+Example
+-------
+
+**Quick Example**:
+
+.. code-block:: python
+
+   import py_osrm
+
+   osrm = py_osrm.OSRM(".tests/test_data/ch/monaco.osrm")
+
+   # Declare Route Coordinates
+   route_params = py_osrm.RouteParameters(
+      coordinates = [(7.41337, 43.72956), (7.41546, 43.73077)]
+   )
+
+   # Pass it into the py_osrm instance
+   res = osrm.Route(route_params)
+
+   # Print out the Distance and Duration of the first Route
+   print("Distance:", res["routes"][0]["distance"])
+   print("Duration:", res["routes"][0]["duration"])

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -21,6 +21,7 @@ source:
    $ cd py-osrm
    $ pip install .
 
+
 Example
 -------
 
@@ -43,3 +44,15 @@ Example
    # Print out the Distance and Duration of the first Route
    print("Distance:", res["routes"][0]["distance"])
    print("Duration:", res["routes"][0]["duration"])
+
+
+Testing
+-------
+py_osrm tests are written for pytest, and can be run from the py_osrm directory.
+
+.. code-block:: console
+   
+   $ git clone https://github.com/gis-ops/py-osrm.git
+   $ cd py-osrm
+   $ pip install .
+   $ pytest


### PR DESCRIPTION
I've added some documentation for `py_osrm`, using Sphinx, so it can be hosted on readthedocs.io. It will require subscribing the project on the readthedocs dashboard after the files are added, though it might require a few more additional file tinkering afterwards to get it working.

I have a test version up here, if you would like to see how it looks and add feedback:
https://whytro-test.readthedocs.io/en/latest/

Some additions that need to be made here are:
 - osrm-datastore/shared memory usage