### PR TITLE
Adjust MacOS CI Workflow

### DIFF
--- a/.github/workflows/osrm-backend.yml
+++ b/.github/workflows/osrm-backend.yml
@@ -25,23 +25,24 @@ jobs:
         fetch-depth: 1
         path: osrm-backend
 
-    - name: Build osrm-backend
+    - name: Build osrm-backend (macos)
+      if: matrix.platform == 'macos'
+      working-directory: osrm-backend
       run: |
         export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1
         brew install lua tbb boost@1.76
         brew link boost@1.76
         
-        cd osrm-backend
         mkdir build && cd build
         cmake ..
         make -j$((`sysctl -n hw.ncpu`+1))
-        cd ../../
-        tar -czf osrm-backend.tgz osrm-backend
+        cd ../
+        tar -czf osrm-backend.tgz build/libosrm* build/osrm-* include profiles third_party/flatbuffers third_party/variant
         du -h osrm-backend.tgz
 
     - name: Archive production artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: osrm-backend
-        path: osrm-backend.tgz
+        name: osrm-backend_${{ matrix.platform }}
+        path: osrm-backend/osrm-backend.tgz
         if-no-files-found: error

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,12 +49,20 @@ jobs:
 
         CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET="10.14"
         CIBW_BEFORE_ALL_MACOS: |
-          gh run download ${{ env.ARTIFACT_ID }} -n osrm-backend
-          tar -zxf osrm-backend.tgz
-          cd osrm-backend/build
+          gh run download ${{ env.ARTIFACT_ID }} -n osrm-backend_${{ matrix.platform }}
+          mkdir osrm-backend
+          tar -zxf osrm-backend.tgz -C osrm-backend
+          cd osrm-backend
+
+          cp -r include /usr/local
+          cp -r third_party/flatbuffers/include /usr/local
+          cp -r third_party/variant/include /usr/local
+          cp -r profiles /usr/local/share/osrm/
+          cd build
+          cp *.a /usr/local/lib
+          cp osrm-* /usr/local/bin
+          cp libosrm.pc /usr/local/lib/pkgconfig
 
           export HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1
           brew install lua tbb boost@1.76
           brew link boost@1.76
-          
-          make install


### PR DESCRIPTION
Adjusted MacOS CI since there was an issue where a difference between CMake versions on the `osrm-backend.yml` runner and the `pull_request.yml` runner was causing the build to fail sporadically. This should also be faster and leaner compared to the old `make install` on target approach.