### PR TITLE
Add CMakeLists adjustments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,11 @@ if(NOT SKBUILD)
   )
 endif()
 
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()
+
 find_package(Python 3.8
   REQUIRED COMPONENTS Interpreter Development.Module
   OPTIONAL_COMPONENTS Development.SABIModule
@@ -29,7 +34,6 @@ execute_process(
   COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
   OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE NB_DIR
 )
-
 list(APPEND CMAKE_PREFIX_PATH "${NB_DIR}")
 find_package(nanobind CONFIG REQUIRED)
 
@@ -101,6 +105,8 @@ else()
   target_include_directories(${EXT_NAME} 
     PUBLIC
       ${libosrm_SOURCE_DIR}/include
+      ${libosrm_SOURCE_DIR}/third_party/variant/include
+      ${libosrm_SOURCE_DIR}/third_party/flatbuffers/include
   )
   target_link_libraries(${EXT_NAME}
     PRIVATE


### PR DESCRIPTION
Added the build type default recommended per nanobind documentation, but also added additional includes for the FetchContent branch, as it would not properly link/compile due to missing third party headers.