### PR TITLE
Fix FetchContent Install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,24 +102,8 @@ else()
     add_subdirectory(
       ${libosrm_SOURCE_DIR}
       ${libosrm_BINARY_DIR}
-      EXCLUDE_FROM_ALL
     )
   endif()
-
-  install(TARGETS osrm-components
-          RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/src/bin)
-  install(TARGETS osrm-contract
-          RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/src/bin)
-  install(TARGETS osrm-customize
-          RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/src/bin)
-  install(TARGETS osrm-datastore
-          RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/src/bin)
-  install(TARGETS osrm-extract
-          RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/src/bin)
-  install(TARGETS osrm-partition
-          RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/src/bin)
-  install(TARGETS osrm-routed
-          RUNTIME DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/src/bin)
 
   target_include_directories(${EXT_NAME} 
     PUBLIC


### PR DESCRIPTION
This fixes an issue where the FetchContent installs were not working on fresh runs. 
A downside of this is that when a wheel is created using FetchContent, other install targets are included into the wheel (ie. include files, share files, lib files), alongside the executables.