### PR TITLE
raw_doc error workaround, add max version to nanobind

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.1"]
+requires = ["scikit-build-core >=0.4.3", "nanobind >=1.3.1,<2"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
The latest version (2.0.0) of nanobind causes errors during the installation process. 

```#0 127.9 Building wheels for collected packages: osrm-bindings
#0 127.9   Building wheel for osrm-bindings (pyproject.toml): started
#0 148.5   Building wheel for osrm-bindings (pyproject.toml): finished with status 'error'
#0 148.5   error: subprocess-exited-with-error
#0 148.5   
#0 148.5   × Building wheel for osrm-bindings (pyproject.toml) did not run successfully.
#0 148.5   │ exit code: 1
#0 148.5   ╰─> [102 lines of output]
#0 148.5       *** scikit-build-core 0.9.5 using CMake 3.25.1 (wheel)
#0 148.5       *** Configuring CMake...
#0 148.5       loading initial cache file build/cp312-abi3-linux_x86_64/CMakeInit.txt
#0 148.5       -- The CXX compiler identification is GNU 12.2.0
#0 148.5       -- Detecting CXX compiler ABI info
#0 148.5       -- Detecting CXX compiler ABI info - done
#0 148.5       -- Check for working CXX compiler: /usr/bin/c++ - skipped
#0 148.5       -- Detecting CXX compile features
#0 148.5       -- Detecting CXX compile features - done
#0 148.5       -- Found Python: /opt/venv/bin/python3 (found suitable version "3.12.3", minimum required is "3.8") found components: Interpreter Development.Module Development.SABIModule
#0 148.5       -- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.1")
#0 148.5       -- Found LibOSRM: /usr/local/lib
#0 148.5       -- Configuring done
#0 148.5       -- Generating done
#0 148.5       -- Build files have been written to: /tmp/pip-req-build-nh4myneh/build/cp312-abi3-linux_x86_64
#0 148.5       *** Building project with Ninja...
#0 148.5       [1/28] Building CXX object CMakeFiles/osrm_ext.dir/src/utility/param_utility.cpp.o
#0 148.5       [2/28] Building CXX object CMakeFiles/osrm_ext.dir/src/parameters/baseparameter_nb.cpp.o
#0 148.5       FAILED: CMakeFiles/osrm_ext.dir/src/parameters/baseparameter_nb.cpp.o
#0 148.5       /usr/bin/c++ -DPy_LIMITED_API=0x030C0000 -Dosrm_ext_EXPORTS -I/tmp/pip-req-build-nh4myneh/include -I/tmp/pip-req-build-nh4myneh/include/utility -I/tmp/pip-req-build-nh4myneh/include/parameters -I/usr/local/include/python3.12 -I/tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include -I/usr/include/lua5.4 -I/usr/local/include -I/usr/local/include/osrm -DBOOST_SPIRIT_USE_PHOENIX_V3 -DBOOST_RESULT_OF_USE_DECLTYPE -DBOOST_FILESYSTEM_NO_DEPRECATED -DBOOST_PHOENIX_STL_TUPLE_H_ -O3 -DNDEBUG -fPIC -fvisibility=hidden -fno-stack-protector -Os -ffunction-sections -fdata-sections -std=c++17 -MD -MT CMakeFiles/osrm_ext.dir/src/parameters/baseparameter_nb.cpp.o -MF CMakeFiles/osrm_ext.dir/src/parameters/baseparameter_nb.cpp.o.d -o CMakeFiles/osrm_ext.dir/src/parameters/baseparameter_nb.cpp.o -c /tmp/pip-req-build-nh4myneh/src/parameters/baseparameter_nb.cpp
#0 148.5       /tmp/pip-req-build-nh4myneh/src/parameters/baseparameter_nb.cpp: In function ‘void init_BaseParameters(nanobind::module_&)’:
#0 148.5       /tmp/pip-req-build-nh4myneh/src/parameters/baseparameter_nb.cpp:17:32: error: ‘raw_doc’ is not a member of ‘nb’
#0 148.5          17 |         .def(nb::init<>(), nb::raw_doc("Instantiates an instance of BaseParameters.\n\n"
#0 148.5             |                                ^~~~~~~
#0 148.5       In file included from /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nanobind.h:52,
#0 148.5                        from /tmp/pip-req-build-nh4myneh/include/parameters/baseparameter_nb.h:6,
#0 148.5                        from /tmp/pip-req-build-nh4myneh/src/parameters/baseparameter_nb.cpp:1:
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h: In instantiation of ‘class nanobind::class_<osrm::engine::api::BaseParameters::SnappingType>’:
#0 148.5       /tmp/pip-req-build-nh4myneh/src/parameters/baseparameter_nb.cpp:56:63:   required from here
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: error: static assertion failed: You attempted to bind a type that is already intercepted by a type caster. Having both at the same time is not allowed. Are you perhaps binding an STL type, while at the same time including a matching type caster from <nanobind/stl/*>? Or did you perhaps forget to declare NB_MAKE_OPAQUE(..) to specifically disable the type caster catch-all for a specific type? Please review the documentation to learn about the difference between bindings and type casters.
#0 148.5         468 |         detail::is_base_caster_v<detail::make_caster<Type>>,
#0 148.5             |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: note: ‘nanobind::detail::is_base_caster_v<nanobind::detail::type_caster<osrm::engine::api::BaseParameters::SnappingType, int> >’ evaluates to false
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h: In instantiation of ‘class nanobind::class_<osrm::engine::api::BaseParameters::OutputFormatType>’:
#0 148.5       /tmp/pip-req-build-nh4myneh/src/parameters/baseparameter_nb.cpp:66:71:   required from here
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: error: static assertion failed: You attempted to bind a type that is already intercepted by a type caster. Having both at the same time is not allowed. Are you perhaps binding an STL type, while at the same time including a matching type caster from <nanobind/stl/*>? Or did you perhaps forget to declare NB_MAKE_OPAQUE(..) to specifically disable the type caster catch-all for a specific type? Please review the documentation to learn about the difference between bindings and type casters.
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: note: ‘nanobind::detail::is_base_caster_v<nanobind::detail::type_caster<osrm::engine::api::BaseParameters::OutputFormatType, int> >’ evaluates to false
#0 148.5       [3/28] Building CXX object CMakeFiles/osrm_ext.dir/src/engineconfig_nb.cpp.o
#0 148.5       FAILED: CMakeFiles/osrm_ext.dir/src/engineconfig_nb.cpp.o
#0 148.5       /usr/bin/c++ -DPy_LIMITED_API=0x030C0000 -Dosrm_ext_EXPORTS -I/tmp/pip-req-build-nh4myneh/include -I/tmp/pip-req-build-nh4myneh/include/utility -I/tmp/pip-req-build-nh4myneh/include/parameters -I/usr/local/include/python3.12 -I/tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include -I/usr/include/lua5.4 -I/usr/local/include -I/usr/local/include/osrm -DBOOST_SPIRIT_USE_PHOENIX_V3 -DBOOST_RESULT_OF_USE_DECLTYPE -DBOOST_FILESYSTEM_NO_DEPRECATED -DBOOST_PHOENIX_STL_TUPLE_H_ -O3 -DNDEBUG -fPIC -fvisibility=hidden -fno-stack-protector -Os -ffunction-sections -fdata-sections -std=c++17 -MD -MT CMakeFiles/osrm_ext.dir/src/engineconfig_nb.cpp.o -MF CMakeFiles/osrm_ext.dir/src/engineconfig_nb.cpp.o.d -o CMakeFiles/osrm_ext.dir/src/engineconfig_nb.cpp.o -c /tmp/pip-req-build-nh4myneh/src/engineconfig_nb.cpp
#0 148.5       In file included from /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nanobind.h:52,
#0 148.5                        from /tmp/pip-req-build-nh4myneh/include/engineconfig_nb.h:6,
#0 148.5                        from /tmp/pip-req-build-nh4myneh/src/engineconfig_nb.cpp:1:
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h: In instantiation of ‘class nanobind::class_<osrm::engine::EngineConfig::Algorithm>’:
#0 148.5       /tmp/pip-req-build-nh4myneh/src/engineconfig_nb.cpp:45:55:   required from here
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: error: static assertion failed: You attempted to bind a type that is already intercepted by a type caster. Having both at the same time is not allowed. Are you perhaps binding an STL type, while at the same time including a matching type caster from <nanobind/stl/*>? Or did you perhaps forget to declare NB_MAKE_OPAQUE(..) to specifically disable the type caster catch-all for a specific type? Please review the documentation to learn about the difference between bindings and type casters.
#0 148.5         468 |         detail::is_base_caster_v<detail::make_caster<Type>>,
#0 148.5             |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: note: ‘nanobind::detail::is_base_caster_v<nanobind::detail::type_caster<osrm::engine::EngineConfig::Algorithm, int> >’ evaluates to false
#0 148.5       [4/28] Building CXX object CMakeFiles/osrm_ext.dir/src/parameters/routeparameter_nb.cpp.o
#0 148.5       FAILED: CMakeFiles/osrm_ext.dir/src/parameters/routeparameter_nb.cpp.o
#0 148.5       /usr/bin/c++ -DPy_LIMITED_API=0x030C0000 -Dosrm_ext_EXPORTS -I/tmp/pip-req-build-nh4myneh/include -I/tmp/pip-req-build-nh4myneh/include/utility -I/tmp/pip-req-build-nh4myneh/include/parameters -I/usr/local/include/python3.12 -I/tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include -I/usr/include/lua5.4 -I/usr/local/include -I/usr/local/include/osrm -DBOOST_SPIRIT_USE_PHOENIX_V3 -DBOOST_RESULT_OF_USE_DECLTYPE -DBOOST_FILESYSTEM_NO_DEPRECATED -DBOOST_PHOENIX_STL_TUPLE_H_ -O3 -DNDEBUG -fPIC -fvisibility=hidden -fno-stack-protector -Os -ffunction-sections -fdata-sections -std=c++17 -MD -MT CMakeFiles/osrm_ext.dir/src/parameters/routeparameter_nb.cpp.o -MF CMakeFiles/osrm_ext.dir/src/parameters/routeparameter_nb.cpp.o.d -o CMakeFiles/osrm_ext.dir/src/parameters/routeparameter_nb.cpp.o -c /tmp/pip-req-build-nh4myneh/src/parameters/routeparameter_nb.cpp
#0 148.5       /tmp/pip-req-build-nh4myneh/src/parameters/routeparameter_nb.cpp: In function ‘void init_RouteParameters(nanobind::module_&)’:
#0 148.5       /tmp/pip-req-build-nh4myneh/src/parameters/routeparameter_nb.cpp:19:32: error: ‘raw_doc’ is not a member of ‘nb’
#0 148.5          19 |         .def(nb::init<>(), nb::raw_doc("Instantiates an instance of RouteParameters.\n\n"
#0 148.5             |                                ^~~~~~~
#0 148.5       In file included from /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nanobind.h:52,
#0 148.5                        from /tmp/pip-req-build-nh4myneh/include/parameters/routeparameter_nb.h:6,
#0 148.5                        from /tmp/pip-req-build-nh4myneh/src/parameters/routeparameter_nb.cpp:1:
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h: In instantiation of ‘class nanobind::class_<osrm::engine::api::RouteParameters::GeometriesType>’:
#0 148.5       /tmp/pip-req-build-nh4myneh/src/parameters/routeparameter_nb.cpp:125:73:   required from here
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: error: static assertion failed: You attempted to bind a type that is already intercepted by a type caster. Having both at the same time is not allowed. Are you perhaps binding an STL type, while at the same time including a matching type caster from <nanobind/stl/*>? Or did you perhaps forget to declare NB_MAKE_OPAQUE(..) to specifically disable the type caster catch-all for a specific type? Please review the documentation to learn about the difference between bindings and type casters.
#0 148.5         468 |         detail::is_base_caster_v<detail::make_caster<Type>>,
#0 148.5             |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: note: ‘nanobind::detail::is_base_caster_v<nanobind::detail::type_caster<osrm::engine::api::RouteParameters::GeometriesType, int> >’ evaluates to false
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h: In instantiation of ‘class nanobind::class_<osrm::engine::api::RouteParameters::OverviewType>’:
#0 148.5       /tmp/pip-req-build-nh4myneh/src/parameters/routeparameter_nb.cpp:135:69:   required from here
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: error: static assertion failed: You attempted to bind a type that is already intercepted by a type caster. Having both at the same time is not allowed. Are you perhaps binding an STL type, while at the same time including a matching type caster from <nanobind/stl/*>? Or did you perhaps forget to declare NB_MAKE_OPAQUE(..) to specifically disable the type caster catch-all for a specific type? Please review the documentation to learn about the difference between bindings and type casters.
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: note: ‘nanobind::detail::is_base_caster_v<nanobind::detail::type_caster<osrm::engine::api::RouteParameters::OverviewType, int> >’ evaluates to false
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h: In instantiation of ‘class nanobind::class_<osrm::engine::api::RouteParameters::AnnotationsType>’:
#0 148.5       /tmp/pip-req-build-nh4myneh/src/parameters/routeparameter_nb.cpp:145:75:   required from here
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: error: static assertion failed: You attempted to bind a type that is already intercepted by a type caster. Having both at the same time is not allowed. Are you perhaps binding an STL type, while at the same time including a matching type caster from <nanobind/stl/*>? Or did you perhaps forget to declare NB_MAKE_OPAQUE(..) to specifically disable the type caster catch-all for a specific type? Please review the documentation to learn about the difference between bindings and type casters.
#0 148.5       /tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include/nanobind/nb_class.h:468:17: note: ‘nanobind::detail::is_base_caster_v<nanobind::detail::type_caster<osrm::engine::api::RouteParameters::AnnotationsType, int> >’ evaluates to false
#0 148.5       [5/28] Building CXX object CMakeFiles/osrm_ext.dir/src/osrm_nb.cpp.o
#0 148.5       FAILED: CMakeFiles/osrm_ext.dir/src/osrm_nb.cpp.o
#0 148.5       /usr/bin/c++ -DPy_LIMITED_API=0x030C0000 -Dosrm_ext_EXPORTS -I/tmp/pip-req-build-nh4myneh/include -I/tmp/pip-req-build-nh4myneh/include/utility -I/tmp/pip-req-build-nh4myneh/include/parameters -I/usr/local/include/python3.12 -I/tmp/pip-build-env-arb7xax9/overlay/lib/python3.12/site-packages/nanobind/include -I/usr/include/lua5.4 -I/usr/local/include -I/usr/local/include/osrm -DBOOST_SPIRIT_USE_PHOENIX_V3 -DBOOST_RESULT_OF_USE_DECLTYPE -DBOOST_FILESYSTEM_NO_DEPRECATED -DBOOST_PHOENIX_STL_TUPLE_H_ -O3 -DNDEBUG -fPIC -fvisibility=hidden -fno-stack-protector -Os -ffunction-sections -fdata-sections -std=c++17 -MD -MT CMakeFiles/osrm_ext.dir/src/osrm_nb.cpp.o -MF CMakeFiles/osrm_ext.dir/src/osrm_nb.cpp.o.d -o CMakeFiles/osrm_ext.dir/src/osrm_nb.cpp.o -c /tmp/pip-req-build-nh4myneh/src/osrm_nb.cpp
#0 148.5       /tmp/pip-req-build-nh4myneh/src/osrm_nb.cpp: In function ‘void nanobind_init_osrm_ext(nanobind::module_&)’:
#0 148.5       /tmp/pip-req-build-nh4myneh/src/osrm_nb.cpp:63:45: error: ‘raw_doc’ is not a member of ‘nb’
#0 148.5          63 |         .def(nb::init<EngineConfig&>(), nb::raw_doc("Instantiates an instance of OSRM.\n\n"
#0 148.5             |                                             ^~~~~~~
#0 148.5       /tmp/pip-req-build-nh4myneh/src/osrm_nb.cpp:116:16: error: ‘raw_doc’ is not a member of ‘nb’
#0 148.5         116 |         }, nb::raw_doc("Matches/snaps given GPS points to the road network in the most plausible way.\n\n"
#0 148.5             |                ^~~~~~~
#0 148.5       /tmp/pip-req-build-nh4myneh/src/osrm_nb.cpp:136:16: error: ‘raw_doc’ is not a member of ‘nb’
#0 148.5         136 |         }, nb::raw_doc("Snaps a coordinate to the street network and returns the nearest matches.\n\n"
#0 148.5             |                ^~~~~~~
#0 148.5       /tmp/pip-req-build-nh4myneh/src/osrm_nb.cpp:156:16: error: ‘raw_doc’ is not a member of ‘nb’
#0 148.5         156 |         }, nb::raw_doc("Finds the fastest route between coordinates in the supplied order.\n\n"
#0 148.5             |                ^~~~~~~
#0 148.5       /tmp/pip-req-build-nh4myneh/src/osrm_nb.cpp:176:16: error: ‘raw_doc’ is not a member of ‘nb’
#0 148.5         176 |         }, nb::raw_doc("Computes the duration of the fastest route between all pairs of supplied coordinates.\n\n"
#0 148.5             |                ^~~~~~~
#0 148.5       /tmp/pip-req-build-nh4myneh/src/osrm_nb.cpp:196:16: error: ‘raw_doc’ is not a member of ‘nb’
#0 148.5         196 |         }, nb::raw_doc("Computes the duration of the fastest route between all pairs of supplied coordinates.\n\n"
#0 148.5             |                ^~~~~~~
#0 148.5       /tmp/pip-req-build-nh4myneh/src/osrm_nb.cpp:216:16: error: ‘raw_doc’ is not a member of ‘nb’
#0 148.5         216 |         }, nb::raw_doc("Solves the Traveling Salesman Problem using a greedy heuristic (farthest-insertion algorithm).\n\n"
#0 148.5             |                ^~~~~~~
#0 148.5       [6/28] Building CXX object CMakeFiles/osrm_ext.dir/src/utility/osrm_utility.cpp.o
#0 148.5       ninja: build stopped: subcommand failed.
#0 148.5       
#0 148.5       *** CMake build failed
#0 148.5       [end of output]
#0 148.5   
#0 148.5   note: This error originates from a subprocess, and is likely not a problem with pip.
#0 148.5   ERROR: Failed building wheel for osrm-bindings
#0 148.5 Failed to build osrm-bindings
#0 148.6 ERROR: Could not build wheels for osrm-bindings, which is required to install pyproject.toml-based projects
```

I have added a max version to nanobind in the pyproject.toml file.